### PR TITLE
Add support for blocking on returns even when there is no return value

### DIFF
--- a/mocks/method.go
+++ b/mocks/method.go
@@ -71,7 +71,17 @@ func (m Method) params() []*ast.Field {
 
 func (m Method) results() []*ast.Field {
 	if m.implements.Results == nil {
-		return nil
+		if !*m.receiver.blockingReturn {
+			return nil
+		}
+		return []*ast.Field{
+			{
+				Names: []*ast.Ident{
+					{Name: "blockReturn"},
+				},
+				Type: &ast.Ident{Name: "bool"},
+			},
+		}
 	}
 	fields := make([]*ast.Field, 0, len(m.implements.Results.List))
 	for idx, f := range m.implements.Results.List {
@@ -134,7 +144,10 @@ func (m Method) returnsExprs() (exprs []ast.Expr) {
 
 func (m Method) returns() ast.Stmt {
 	if m.implements.Results == nil {
-		return nil
+		if !*m.receiver.blockingReturn {
+			return nil
+		}
+		return &ast.ExprStmt{X: m.returnsExprs()[0]}
 	}
 	return &ast.ReturnStmt{Results: m.returnsExprs()}
 }

--- a/mocks/mock.go
+++ b/mocks/mock.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Mock struct {
-	typeName   string
-	implements *ast.InterfaceType
+	typeName       string
+	implements     *ast.InterfaceType
+	blockingReturn *bool
 }
 
 func For(typ *ast.TypeSpec) (Mock, error) {
@@ -19,9 +20,11 @@ func For(typ *ast.TypeSpec) (Mock, error) {
 	if !ok {
 		return Mock{}, fmt.Errorf("TypeSpec.Type expected to be *ast.InterfaceType, was %T", typ.Type)
 	}
+	var blockingReturn bool
 	m := Mock{
-		typeName:   typ.Name.String(),
-		implements: inter,
+		typeName:       typ.Name.String(),
+		implements:     inter,
+		blockingReturn: &blockingReturn,
 	}
 	return m, nil
 }
@@ -44,6 +47,10 @@ func (m Mock) PrependLocalPackage(name string) {
 	for _, m := range m.Methods() {
 		m.PrependLocalPackage(name)
 	}
+}
+
+func (m Mock) SetBlockingReturn(blockingReturn bool) {
+	*m.blockingReturn = blockingReturn
 }
 
 func (m Mock) Constructor(chanSize int) *ast.FuncDecl {

--- a/mocks/mock_test.go
+++ b/mocks/mock_test.go
@@ -95,6 +95,37 @@ func TestMockTypeDecl(t *testing.T) {
 
 	src = source(expect, "foo", []ast.Decl{m.Decl()}, nil)
 	expect(src).To.Equal(string(expected))
+
+	m.SetBlockingReturn(true)
+
+	expected, err = format.Source([]byte(`
+ package foo
+ 
+ type mockFoo struct {
+  FooCalled chan bool
+  FooInput struct {
+   foo chan string
+  }
+  FooOutput struct {
+   ret0 chan int
+  }
+  BarCalled chan bool
+  BarInput struct {
+   bar chan int
+  }
+  BarOutput struct {
+   ret0 chan foo.Foo
+  }
+  BazCalled chan bool
+  BazOutput struct {
+   blockReturn chan bool
+  }
+ }
+ `))
+	expect(err).To.Be.Nil()
+
+	src = source(expect, "foo", []ast.Decl{m.Decl()}, nil)
+	expect(src).To.Equal(string(expected))
 }
 
 func TestMockTypeDecl_DirectionalChansGetParens(t *testing.T) {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -29,6 +29,12 @@ func (m Mocks) PrependLocalPackage(name string) {
 	}
 }
 
+func (m Mocks) SetBlockingReturn(blockingReturn bool) {
+	for _, m := range m {
+		m.SetBlockingReturn(blockingReturn)
+	}
+}
+
 func (m Mocks) decls(chanSize int) (decls []ast.Decl) {
 	for _, mock := range m {
 		decls = append(decls, mock.Ast(chanSize)...)


### PR DESCRIPTION
This flag enables mock methods to block on returning even if they don't have a return value. This allows the user to control when the mock method returns.

Example interface:

```go
//go:generate hel --type Foo --blocking-return

type Foo interface {
	Bar()
}
```

Resulting mock:

```go
type mockFoo struct {
	BarCalled chan bool
	BarOutput struct {
		ret0 chan bool
	}
}

func newMockFoo() *mockFoo {
	m := &mockFoo{}
	m.BarCalled = make(chan bool, 100)
	m.BarOutput.ret0 = make(chan bool, 100)
	return m
}
func (m *mockFoo) Bar() {
	m.BarCalled <- true
	<-m.BarOutput.ret0
}
```