### PR TITLE
Modified blocking return to have more intuitive behavior

### DIFF
--- a/mocks/method_test.go
+++ b/mocks/method_test.go
@@ -99,7 +99,11 @@ func TestMockMethodWithBlockingReturn(t *testing.T) {
 
  func (m *mockFoo) Foo() () {
    m.FooCalled <- true
-   <-m.FooOutput.BlockReturn
+   select {
+   case <-m.FooOutput.BlockReturn:
+       <-m.FooOutput.UnblockReturn
+   default:
+   }
  }`))
 	expect(err).To.Be.Nil()
 

--- a/mocks/mock_test.go
+++ b/mocks/mock_test.go
@@ -119,6 +119,7 @@ func TestMockTypeDecl(t *testing.T) {
   BazCalled chan bool
   BazOutput struct {
    BlockReturn chan bool
+   UnblockReturn chan bool
   }
  }
  `))

--- a/mocks/mocks_test.go
+++ b/mocks/mocks_test.go
@@ -203,6 +203,7 @@ func TestOutput(t *testing.T) {
   BazCalled chan bool
   BazOutput struct {
    BlockReturn chan bool
+   UnblockReturn chan bool
   }
  }
 
@@ -213,6 +214,7 @@ func TestOutput(t *testing.T) {
   m.FooOutput.Ret0 = make(chan foo.Foo, 100)
   m.BazCalled = make(chan bool, 100)
   m.BazOutput.BlockReturn = make(chan bool, 100)
+  m.BazOutput.UnblockReturn = make(chan bool, 100)
   return m
  }
  func (m *mockBar) Foo(foo string) foo.Foo {
@@ -222,7 +224,11 @@ func TestOutput(t *testing.T) {
  }
  func (m *mockBar) Baz() {
   m.BazCalled <- true
-  <-m.BazOutput.BlockReturn
+  select {
+  case <-m.BazOutput.BlockReturn:
+      <-m.BazOutput.UnblockReturn
+  default:
+  }
  }
  `))
 	expect(err).To.Be.Nil()


### PR DESCRIPTION
Instead of methods blocking by default, changed blocking return behavior to require user activation. Also created an additional channel that can be used to unblock a mock method call once it has been set to blocked.