### PR TITLE
prepend package names to pointer types

### DIFF
--- a/mocks/method.go
+++ b/mocks/method.go
@@ -301,6 +301,9 @@ func (m Method) prependTypePackage(name string, typ ast.Expr) ast.Expr {
 		src.Key = m.prependTypePackage(name, src.Key)
 		src.Value = m.prependTypePackage(name, src.Value)
 		return src
+	case *ast.StarExpr:
+		src.X = m.prependTypePackage(name, src.X)
+		return src
 	default:
 		return typ
 	}

--- a/mocks/method_test.go
+++ b/mocks/method_test.go
@@ -218,7 +218,7 @@ func TestMockMethodLocalTypes(t *testing.T) {
 
 	spec := typeSpec(expect, `
  type Foo interface {
-   Foo(bar bar.Bar, baz func(f Foo) error) (Foo, func() Foo, error)
+   Foo(bar bar.Bar, baz func(f Foo) error) (*Foo, func() Foo, error)
  }`)
 	mock, err := mocks.For(spec)
 	expect(err).To.Be.Nil().Else.FailNow()
@@ -227,7 +227,7 @@ func TestMockMethodLocalTypes(t *testing.T) {
 	expected, err := format.Source([]byte(`
  package foo
 
- func (m *mockFoo) Foo(bar bar.Bar, baz func(f Foo) error) (Foo, func() Foo, error) {
+ func (m *mockFoo) Foo(bar bar.Bar, baz func(f Foo) error) (*Foo, func() Foo, error) {
    m.FooCalled <- true
    m.FooInput.Bar <- bar
    m.FooInput.Baz <- baz
@@ -243,7 +243,7 @@ func TestMockMethodLocalTypes(t *testing.T) {
 	expected, err = format.Source([]byte(`
  package foo
 
- func (m *mockFoo) Foo(bar bar.Bar, baz func(f foo.Foo) error) (foo.Foo, func() foo.Foo, error) {
+ func (m *mockFoo) Foo(bar bar.Bar, baz func(f foo.Foo) error) (*foo.Foo, func() foo.Foo, error) {
    m.FooCalled <- true
    m.FooInput.Bar <- bar
    m.FooInput.Baz <- baz


### PR DESCRIPTION
mocks with pointer types don't prepend package names producing uncompilable code

presently, mock defined in package `foo`
```go
package foo

type Bar struct{}

type ArgRetStar interface {
	Whatever(*Bar) *Bar
}
```

generates `helheim_test.go` missing the imported `foo` package and `foo` package prepended to `Bar` types and not compile
```go
package foo_test

type mockArgRetStar struct {
	WhateverCalled chan bool
	WhateverInput  struct {
		Arg0 chan *Bar
	}
	WhateverOutput struct {
		Ret0 chan *Bar
	}
}
```

which is borked
```go
$ go test
# github.com/nelsam/hel/foo_test
./helheim_test.go:11: undefined: Bar
./helheim_test.go:14: undefined: Bar
FAIL	github.com/nelsam/hel/foo [build failed]
```

but have no fear, for this pr addresses it
```go
package foo_test

import "github.com/nelsam/hel/foo"

type mockArgRetStar struct {
	WhateverCalled chan bool
	WhateverInput  struct {
		Arg0 chan *foo.Bar
	}
	WhateverOutput struct {
		Ret0 chan *foo.Bar
	}
}
```