### PR TITLE
pers: add a matcher for matching function execution

### DIFF
--- a/pers/havebeenexecuted.go
+++ b/pers/havebeenexecuted.go
@@ -1,0 +1,112 @@
+// This is free and unencumbered software released into the public
+// domain.  For more information, see <http://unlicense.org> or the
+// accompanying UNLICENSE file.
+
+package pers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// HaveMethodExecutedOption is an option function for the HaveMethodExecutedMatcher.
+type HaveMethodExecutedOption func(HaveMethodExecutedMatcher) HaveMethodExecutedMatcher
+
+// Within returns a HaveMethodExecutedOption which sets the HaveMethodExecutedMatcher
+// to be executed within a given timeframe.
+func Within(d time.Duration) HaveMethodExecutedOption {
+	return func(m HaveMethodExecutedMatcher) HaveMethodExecutedMatcher {
+		m.within = d
+		return m
+	}
+}
+
+// WithArgs returns a HaveMethodExecutedOption which sets the HaveMethodExecutedMatcher
+// to only pass if the latest execution of the method called it with the passed in
+// arguments.
+func WithArgs(args ...interface{}) HaveMethodExecutedOption {
+	return func(m HaveMethodExecutedMatcher) HaveMethodExecutedMatcher {
+		m.args = args
+		return m
+	}
+}
+
+// HaveMethodExecutedMatcher is a matcher to ensure that a method on a mock was
+// executed.
+type HaveMethodExecutedMatcher struct {
+	MethodName string
+	within     time.Duration
+	args       []interface{}
+}
+
+// HaveMethodExecuted returns a matcher that asserts that the method referenced
+// by name was executed.  Options can modify the behavior of the matcher.
+func HaveMethodExecuted(name string, opts ...HaveMethodExecutedOption) HaveMethodExecutedMatcher {
+	m := HaveMethodExecutedMatcher{MethodName: name}
+	for _, opt := range opts {
+		m = opt(m)
+	}
+	return m
+}
+
+// Match checks the mock value v to see if it has a method matching m.MethodName
+// which has been called.
+func (m HaveMethodExecutedMatcher) Match(v interface{}) (interface{}, error) {
+	mv := reflect.ValueOf(v)
+	if mv.Kind() == reflect.Ptr {
+		mv = mv.Elem()
+	}
+	calledField := mv.FieldByName(m.MethodName + "Called")
+	cases := []reflect.SelectCase{
+		{Dir: reflect.SelectRecv, Chan: calledField},
+	}
+	switch m.within {
+	case 0:
+		cases = append(cases, reflect.SelectCase{Dir: reflect.SelectDefault})
+	default:
+		cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(time.After(m.within))})
+	}
+
+	chosen, _, _ := reflect.Select(cases)
+	if chosen == 1 {
+		return v, fmt.Errorf("pers: expected method %s to have been called, but it was not", m.MethodName)
+	}
+	inputField := mv.FieldByName(m.MethodName + "Input")
+	var matches [][]interface{}
+	for i := 0; i < inputField.NumField(); i++ {
+		fv, ok := inputField.Field(i).Recv()
+		if !ok {
+			return v, fmt.Errorf("pers: field %s is closed; cannot perform matches against this mock", inputField.Type().Field(i).Name)
+		}
+		matches = append(matches, []interface{}{fv.Interface()})
+	}
+	if len(m.args) == 0 {
+		return v, nil
+	}
+	if len(m.args) != inputField.NumField() {
+		return v, fmt.Errorf("pers: expected %d arguments, but got %d", inputField.NumField(), len(m.args))
+	}
+	matched := true
+	for i, a := range m.args {
+		matches[i] = append(matches[i], a)
+		if matches[i][0] != a {
+			matched = false
+		}
+	}
+	if matched {
+		return v, nil
+	}
+	msg := "pers: %s was called with (%s); expected (%s)"
+	var actual, expected []string
+	for _, match := range matches {
+		format := "%#v"
+		if match[0] != match[1] {
+			format = ">%#v<"
+		}
+		actual = append(actual, fmt.Sprintf(format, match[0]))
+		expected = append(expected, fmt.Sprintf(format, match[1]))
+	}
+	return v, fmt.Errorf(msg, m.MethodName, strings.Join(actual, ", "), strings.Join(expected, ", "))
+}

--- a/pers/havebeenexecuted_test.go
+++ b/pers/havebeenexecuted_test.go
@@ -1,0 +1,144 @@
+// This is free and unencumbered software released into the public
+// domain.  For more information, see <http://unlicense.org> or the
+// accompanying UNLICENSE file.
+
+package pers_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nelsam/hel/pers"
+	"github.com/poy/onpar"
+	"github.com/poy/onpar/expect"
+)
+
+type fakeMock struct {
+	FooCalled chan struct{}
+	FooInput  struct {
+		Arg0 chan int
+		Arg1 chan string
+	}
+	FooOutput struct {
+		Err chan error
+	}
+}
+
+func newFakeMock() *fakeMock {
+	m := &fakeMock{}
+	m.FooCalled = make(chan struct{}, 100)
+	m.FooInput.Arg0 = make(chan int, 100)
+	m.FooInput.Arg1 = make(chan string, 100)
+	m.FooOutput.Err = make(chan error, 100)
+	return m
+}
+
+func (m *fakeMock) Foo(arg0 int, arg1 string) error {
+	m.FooCalled <- struct{}{}
+	m.FooInput.Arg0 <- arg0
+	m.FooInput.Arg1 <- arg1
+	return <-m.FooOutput.Err
+}
+
+func TestHaveMethodExecuted(t *testing.T) {
+	o := onpar.New()
+	defer o.Run(t)
+
+	o.BeforeEach(func(t *testing.T) (*testing.T, expectation) {
+		return t, expect.New(t)
+	})
+
+	o.Spec("it drains a value off of each relevant channel", func(t *testing.T, expect expectation) {
+		fm := newFakeMock()
+		fm.FooCalled <- struct{}{}
+		fm.FooInput.Arg0 <- 0
+		fm.FooInput.Arg1 <- "foo"
+
+		m := pers.HaveMethodExecuted("Foo")
+		m.Match(fm)
+
+		select {
+		case <-fm.FooCalled:
+			t.Fatal("Expected HaveMethodExecuted to drain from the mock's FooCalled channel")
+		case <-fm.FooInput.Arg0:
+			t.Fatal("Expected HaveMethodExecuted to drain from the mock's first FooInput channel")
+		case <-fm.FooInput.Arg1:
+			t.Fatal("Expected HaveMethodExecuted to drain frim the mock's second FooInput channel")
+		default:
+		}
+	})
+
+	o.Spec("it returns a success when the method has been called", func(t *testing.T, expect expectation) {
+		fm := newFakeMock()
+		fm.FooOutput.Err <- nil
+		fm.Foo(1, "foo")
+
+		m := pers.HaveMethodExecuted("Foo")
+		_, err := m.Match(fm)
+		expect(err).To(not(haveOccurred()))
+	})
+
+	o.Spec("it returns a failure when the method has _not_ been called", func(t *testing.T, expect expectation) {
+		m := pers.HaveMethodExecuted("Foo")
+		_, err := m.Match(newFakeMock())
+		expect(err).To(haveOccurred())
+		expect(err.Error()).To(equal("pers: expected method Foo to have been called, but it was not"))
+	})
+
+	o.Spec("it waits for a method to be called", func(t *testing.T, expect expectation) {
+		fm := newFakeMock()
+		fm.FooOutput.Err <- nil
+
+		m := pers.HaveMethodExecuted("Foo", pers.Within(100*time.Millisecond))
+		errs := make(chan error)
+		go func() {
+			_, err := m.Match(fm)
+			errs <- err
+		}()
+
+		fm.Foo(10, "bar")
+		select {
+		case err := <-errs:
+			expect(err).To(not(haveOccurred()))
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Expected Match to wait for Foo to be called")
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		arg0 int
+		arg1 string
+		err  error
+	}{
+		{
+			name: "fails due to a mismatch on the first argument",
+			arg0: 122,
+			arg1: "this is a value",
+			err:  errors.New(`pers: Foo was called with (>123<, "this is a value"); expected (>122<, "this is a value")`),
+		},
+		{
+			name: "fails due to a mismatch on the first argument",
+			arg0: 123,
+			arg1: "this is a val",
+			err:  errors.New(`pers: Foo was called with (123, >"this is a value"<); expected (122, >"this is a val"<)`),
+		},
+		{
+			name: "passes when arguments match",
+			arg0: 123,
+			arg1: "this is a value",
+			err:  nil,
+		},
+	} {
+		o.Spec(test.name, func(t *testing.T, expect expectation) {
+			fm := newFakeMock()
+			fm.FooOutput.Err <- nil
+			fm.Foo(123, "this is a value")
+
+			m := pers.HaveMethodExecuted("Foo", pers.WithArgs(test.arg0, test.arg1))
+			_, err := m.Match(fm)
+			expect(err).To(equal(test.err))
+		})
+	}
+}


### PR DESCRIPTION
HaveBeenExecuted() will now work for matching mocks that were executed
in the expected way.