### PR TITLE
pers: support variadic method arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,8 @@ os:
 - osx
 
 go:
-- "1.9.6"
-- "1.10.2"
-- tip
-
-matrix:
-  allow_failures:
-  - go: tip
+- "1.12.x"
+- "1.13.x"
 
 install:
 - go get golang.org/x/lint/golint


### PR DESCRIPTION
In addition:

- Include a diff function temporarily.  We will likely make use of the
  diffing functionality being worked on in poy/onpar later, but for now,
  this was kind of needed.
- Add some cleaner error handling for cases where the requested method
  doesn't exist.