### PR TITLE
pers: add an 'Any' value that can be used in matchers

### DIFF
--- a/pers/havemethodexecuted.go
+++ b/pers/havemethodexecuted.go
@@ -11,6 +11,13 @@ import (
 	"time"
 )
 
+type any int
+
+// Any is a special value to tell pers to allow any value at the position used.
+// For example, you can assert only on the second argument with:
+//     HaveMethodExecuted("Foo", WithArgs(Any, 22))
+const Any any = -1
+
 // HaveMethodExecutedOption is an option function for the HaveMethodExecutedMatcher.
 type HaveMethodExecutedOption func(HaveMethodExecutedMatcher) HaveMethodExecutedMatcher
 
@@ -145,11 +152,10 @@ func diff(actual, expected interface{}) (matched bool, actualOutput, expectedOut
 	return diffV(reflect.ValueOf(actual), reflect.ValueOf(expected))
 }
 
-type span struct {
-	start, end int
-}
-
 func diffV(av, ev reflect.Value) (matched bool, actualOutput, expectedOutput string) {
+	if ev.Interface() == Any {
+		return true, fmt.Sprintf("%#v", av.Interface()), "{ANY}"
+	}
 	if av.Kind() != ev.Kind() {
 		format := ">type mismatch: %#v<"
 		return false, fmt.Sprintf(format, av.Interface()), fmt.Sprintf(format, ev.Interface())

--- a/pers/havemethodexecuted_test.go
+++ b/pers/havemethodexecuted_test.go
@@ -153,8 +153,8 @@ func TestHaveMethodExecuted(t *testing.T) {
 
 	for _, test := range []struct {
 		name string
-		arg0 int
-		arg1 string
+		arg0 interface{}
+		arg1 interface{}
 		err  error
 	}{
 		{
@@ -164,10 +164,10 @@ func TestHaveMethodExecuted(t *testing.T) {
 			err:  errors.New(`pers: Foo was called with (>123<, "this is a value"); expected (>122<, "this is a value")`),
 		},
 		{
-			name: "fails due to a mismatch on the first argument",
+			name: "fails due to a mismatch on the second argument",
 			arg0: 123,
 			arg1: "this is a val",
-			err:  errors.New(`pers: Foo was called with (123, >"this is a value"<); expected (122, >"this is a val"<)`),
+			err:  errors.New(`pers: Foo was called with (123, >"this is a value"<); expected (123, >"this is a val"<)`),
 		},
 		{
 			name: "passes when arguments match",
@@ -175,7 +175,14 @@ func TestHaveMethodExecuted(t *testing.T) {
 			arg1: "this is a value",
 			err:  nil,
 		},
+		{
+			name: "passes when Any is passed in",
+			arg0: pers.Any,
+			arg1: pers.Any,
+			err:  nil,
+		},
 	} {
+		test := test
 		o.Spec(test.name, func(t *testing.T, expect expectation) {
 			fm := newFakeMock()
 			fm.FooOutput.Err <- nil


### PR DESCRIPTION
Any: a new constant (magic) value to tell pers that the caller doesn't care about that value.

tests: turns out our table tests weren't working and one of our tests was broken.  fixed.